### PR TITLE
Couple of fixes

### DIFF
--- a/lib/Bio/Phylo/Forest/Node.pm
+++ b/lib/Bio/Phylo/Forest/Node.pm
@@ -1845,7 +1845,7 @@ Calculates patristic distance between invocant and argument.
 
     sub calc_patristic_distance {
         my ( $self, $other_node ) = @_;
-        my $patristic_distance;
+        my $patristic_distance = 0;
         my $mrca    = $self->get_mrca($other_node);
         my $mrca_id = $mrca->get_id;
         while ( $self->get_id != $mrca_id ) {
@@ -1882,7 +1882,7 @@ Calculates node distance between invocant and argument.
 
     sub calc_nodal_distance {
         my ( $self, $other_node ) = @_;
-        my $nodal_distance;
+        my $nodal_distance = 0;
         my $mrca    = $self->get_mrca($other_node);
         my $mrca_id = $mrca->get_id;
         while ( $self and $self->get_id != $mrca_id ) {

--- a/t/03-node.t
+++ b/t/03-node.t
@@ -138,6 +138,8 @@ ok( $trees[3]->get_root->get_name eq 'root', '73 reroot tree' );
     ok( $subtree1->calc_symdiff($subtree2) == 0, '76 clone subtree' );
 }
 is($node->get_mrca($node), $node);
+is($node->calc_patristic_distance($node), 0);
+is($node->calc_nodal_distance($node), 0);
 
 __DATA__
 (H:1,(G:1,(F:1,(E:1,(D:1,(C:1,(A:1,B:1):1):1):1):1):1):1):0;


### PR DESCRIPTION
Hi Rutger,
I have noticed an of issues with the calc_*_distance methods: when calculating the distance between a node and itself, the distance was larger than 0. This is partially due to a bug in get_mrsa. Luckily, it was not very hard to track down and fix. See attached commits. Enjoy,
Florent
