### PR TITLE
Pruning without removing nodes with single child that were already in tree

### DIFF
--- a/lib/Bio/Phylo/Forest/TreeRole.pm
+++ b/lib/Bio/Phylo/Forest/TreeRole.pm
@@ -2341,7 +2341,7 @@ Keeps argument nodes from invocant (i.e. prunes all others).
     sub _get_tip_objects {
         my ( $self, $arg ) = @_;
         my @tips;
-        
+
         # argument is a taxa block
         if ( blessed $arg ) {
             for my $taxon ( @{ $arg->get_entities } ) {
@@ -2351,40 +2351,40 @@ Keeps argument nodes from invocant (i.e. prunes all others).
                 }
             }
         }
-        
+
         # arg is an array ref
         else {
             my $TAXON = _TAXON_;
             my $NODE  = _NODE_;
             for my $thing ( @{ $arg } ) {
-                
+
                 # thing is a taxon or node object
                 if ( blessed $thing ) {
                     if ( $thing->_type == $TAXON ) {
                         my @nodes = @{ $thing->get_nodes };
                         for my $node ( @nodes ) {
                             push @tips, $node if $self->contains($node);
-                        }                        
+                        }
                     }
                     elsif ( $thing->_type == $NODE ) {
                         push @tips, $thing if $self->contains($thing);
                     }
                 }
-                
+
                 # thing is a name
                 else {
                     if ( my $tip = $self->get_by_name($thing) ) {
                         push @tips, $tip;
                     }
                 }
-            }            
+            }
         }
         return \@tips;
     }
 
     sub keep_tips {
         my ( $self, $tip_names ) = @_;
-        
+
         # get node objects for tips
         my @tips = @{ $self->_get_tip_objects($tip_names) };
         
@@ -2400,34 +2400,42 @@ Keeps argument nodes from invocant (i.e. prunes all others).
                 }
                 else {
                     last PARENT;
-                }            
+                }
             }
         }
-        
+
         # now do the pruning
         $self->visit_depth_first(
             '-post' => sub {
+                # prune node
                 my $n = shift;
-                # remove unwanted node
+                my $nid = $n->get_id;
                 my $p = $n->get_parent;
-                if ( not exists $seen{$n->get_id} ) {
+                if ( not exists $seen{$nid} ) {
                     $p->delete($n) if $p;
                     $self->delete($n);
+                    # record number of children lost by parent
+                    if (defined $p) {
+                       my $pid = $p->get_id;
+                       if ( exists $seen{$pid} ) {
+                          $seen{$pid}++;
+                       }
+                    }
                     return;
                 }
-                # remove parent with single child
+                # remove nodes who lost children and are now down to a single one
                 my @children = @{ $n->get_children };
-                if ( scalar(@children) == 1 ) {
+                if ( (scalar @children == 1) && ($seen{$nid} > 0) ) {
                     my ($c) = @children;
                     my $bl  = $n->get_branch_length;
-                    my $cbl = $c->get_branch_length;                
+                    my $cbl = $c->get_branch_length;
                     $c->set_branch_length( $bl + $cbl ) if defined $cbl && defined $bl;
-                    $self->delete($n);                                
+                    $self->delete($n);
                     $c->set_parent($p);
                     $p->delete($n) if $p;
                 }
             }
-        );        
+        );
         return $self;
     }
 

--- a/t/06-tree.t
+++ b/t/06-tree.t
@@ -240,6 +240,22 @@ ok( $ladder->ladderize->to_newick eq $right, '49 ladderize' );
     my @cherries = @{ $tree->get_cherries };
     ok( scalar(@cherries) == 2, '67 get cherries' );
 }
+
+# Try pruning
+{
+    my $newick = '((A,(C,X)Int1)LUCA);';
+    my $tree = parse( '-format' => 'newick', '-string' => $newick )->first;
+    my $root = $tree->get_root->set_name('root');
+    my @names = sort map {$_->get_name} @{$tree->get_entities};
+    ok( $tree->keep_tips(\@names), 'pruning' );
+    my @pruned_names = sort map {$_->get_name} @{$tree->get_entities};
+    is_deeply(\@pruned_names, \@names);
+    @names = ('A', 'C');
+    ok( $tree->keep_tips(\@names) );
+    @pruned_names = sort map {$_->get_name} @{$tree->get_entities};
+    is_deeply( \@pruned_names, [@names, 'LUCA', 'root']);
+}
+
 __DATA__
 ((H:1,I:1):1,(G:1,(F:0.01,(E:0.3,(D:2,(C:0.1,(A:1,B:1)cherry:1):1):1):1):1):1):0;
 (H:1,(G:1,(F:1,((C:1,(A:1,B:1):1):1,(D:1,E:1):1):1):1):1):0;


### PR DESCRIPTION
Hi Rutger,
The code for keep_tips() removes unwanted tips and goes the extra mile to also remove nodes that have a single child. In a case I had, my tree contained some nodes with single children, prior to pruning. I pruned some tips and my nodes with single child were removed, even though their child was not affected by the pruning operation. So, here is a pull request containing code to preserve nodes with single child that were already present in tree. The test suite was updated and all tests pass.
Cheers,
Florent
