### PR TITLE
"use strict;" in all perl modules

### DIFF
--- a/lib/Bio/Phylo/Identifiable.pm
+++ b/lib/Bio/Phylo/Identifiable.pm
@@ -2,6 +2,9 @@ package Bio::Phylo::Identifiable;
 use Bio::Phylo::Util::IDPool;
 use Bio::Phylo::Util::Exceptions 'throw';
 
+use strict;
+use warnings;
+
 =head1 NAME
 
 Bio::Phylo::Identifiable - Objects with unique identifiers

--- a/lib/Bio/Phylo/Util/CONSTANT/Int.pm
+++ b/lib/Bio/Phylo/Util/CONSTANT/Int.pm
@@ -1,4 +1,8 @@
 package Bio::Phylo::Util::CONSTANT::Int;
+
+use strict;
+use warnings;
+
 sub _NONE_ ()          { 1 }
 sub _NODE_ ()          { 2 }
 sub _TREE_ ()          { 3 }

--- a/lib/Bio/Phylo/Util/Dependency.pm
+++ b/lib/Bio/Phylo/Util/Dependency.pm
@@ -1,5 +1,8 @@
 package Bio::Phylo::Util::Dependency;
 
+use strict;
+use warnings;
+
 BEGIN {
     use Bio::Phylo::Util::Exceptions 'throw';
     use Bio::Phylo::Util::CONSTANT 'looks_like_class';

--- a/t/00-load.t
+++ b/t/00-load.t
@@ -1,6 +1,9 @@
 # $Id: 00-load.t 838 2009-03-04 20:47:20Z rvos $
 use Test::More tests => 1;
 
+use strict;
+use warnings;
+
 BEGIN {
     use_ok('Bio::Phylo');
 }

--- a/t/32-tolweb.t
+++ b/t/32-tolweb.t
@@ -1,4 +1,6 @@
 use Test::More;
+use strict;
+use warnings;
 
 BEGIN {
     eval { require XML::Twig };

--- a/t/pod-coverage.t
+++ b/t/pod-coverage.t
@@ -1,6 +1,8 @@
 #!perl
 # $Id: pod-coverage.t 1257 2010-03-04 17:43:43Z rvos $
 use Test::More;
+use strict;
+use warnings;
 plan skip_all => 'env var TEST_AUTHOR not set' if not $ENV{'TEST_AUTHOR'};
 eval "use Test::Pod::Coverage 1.04";
 plan skip_all => "Test::Pod::Coverage 1.04 required for testing POD coverage"

--- a/t/pod.t
+++ b/t/pod.t
@@ -1,6 +1,8 @@
 #!perl
 # $Id: pod.t 838 2009-03-04 20:47:20Z rvos $
 use Test::More;
+use strict;
+use warnings;
 eval "use Test::Pod 1.14";
 plan skip_all => "Test::Pod 1.14 required for testing POD" if $@;
 all_pod_files_ok();

--- a/t/regress_21417.t
+++ b/t/regress_21417.t
@@ -1,5 +1,8 @@
 use Bio::Phylo::IO 'parse';
 use Test::More tests => 1;
+use strict;
+use warnings;
+
 my $tree = parse(
     -format => 'newick',
     -string => do { local $/ = undef; <DATA> }

--- a/t/regress_22813.t
+++ b/t/regress_22813.t
@@ -1,4 +1,6 @@
 use Test::More;
+use strict;
+use warnings;
 
 BEGIN {
     eval { require SVG };

--- a/t/regress_41070.t
+++ b/t/regress_41070.t
@@ -1,4 +1,6 @@
 use Test::More;
+use strict;
+use warnings;
 
 BEGIN {
     eval { require Bio::TreeIO };


### PR DESCRIPTION
... also also some `use warnings;`.

This should make http://cpants.cpanauthors.org/dist/Bio-Phylo happier,
and IMHO it is a good idea anyway :-)

All tests still pass for me.